### PR TITLE
Desambigua representant legal que es traduïa com a 'representando'

### DIFF
--- a/apertium-cat.cat.rlx
+++ b/apertium-cat.cat.rlx
@@ -493,6 +493,8 @@ REMOVE (acr) IF (-1 BOS OR AllUpper) (0 ("<A>")) ;
 
 SELECT N IF (0 ("sant")) (1 NP) ;
 
+SELECT N IF (0 ("representant") + Sg) (1 A + Sg) ; #representant legal, comercial
+
 REMOVE NP IF (0 ("Serra") + FemSg) (-1/* Det + FemSg); # la Serra A...
 REMOVE NP IF (0 ("Mestre") + MascSg) (-1/* Det + MascSg); # el Mestre A...
 REMOVE NP IF (0 ("Mestre")) (1 ("internacional"));


### PR DESCRIPTION
Actualment "representant legal de l’entitat" -> "Representando legal de la entidad", després del canvi "Representante legal de la entidad". Aquesta fórmula és comuna en textos administratius.

Usant catalan-dict-tools, vaig fer una llistat de tots els gerundis amb formes que coincidien amb noms (visitant, vigilant, representant, sol·licitant, etc) i 'representant' és l'únic que sembla donar aquest problema.